### PR TITLE
Fix: Avoid logout on migrated accounts

### DIFF
--- a/src/util/Injected/Store.js
+++ b/src/util/Injected/Store.js
@@ -229,5 +229,5 @@ exports.ExposeStore = () => {
 
     window.injectToFunction({ module: 'WAWebE2EProtoUtils', function: 'typeAttributeFromProtobuf' }, (func, ...args) => { const [proto] = args; return proto.locationMessage || proto.groupInviteMessage ? 'text' : func(...args); });
 
-    window.injectToFunction({ module: 'WAWebLid1X1MigrationGating', function: 'Lid1X1MigrationUtils.isLidMigrated' }, () => false);
+    window.injectToFunction({ module: 'WAWebLid1X1MigrationGating', function: 'Lid1X1MigrationUtils.isLidMigrated' }, (func, ...args) => { try { return func(...args); } catch { return false; }});
 };


### PR DESCRIPTION
This PR adjusts the injection of Lid1X1MigrationUtils.isLidMigrated in src/util/Injected/Store.js.

Before, the function was always forced to return false.

That worked fine for accounts that hadn’t been migrated yet, but for accounts already using the new LID 1x1 system it caused an immediate logout, since the client detected a mismatch.

What changed

The injection now tries to run the original function first.

If that fails, it falls back to returning false.

Result

Non-migrated accounts behave as before.

Migrated accounts no longer get logged out right after login.

This makes the patch compatible with both types of accounts without breaking existing behavior.