### PR TITLE
fix(lid): rebuild MsgKey _serialized from consistent remote in getMessageModel

### DIFF
--- a/src/util/Injected/Utils.js
+++ b/src/util/Injected/Utils.js
@@ -836,11 +836,39 @@ exports.LoadUtils = () => {
             });
         }
 
-        // WhatsApp Web changed _serialized to $1 in message IDs (2026-07 update).
-        // Normalize here so all downstream Node.js code can keep using _serialized.
-        if (msg.id && msg.id._serialized == null && msg.id.$1 != null) {
-            msg.id = Object.assign({}, msg.id, { _serialized: msg.id.$1 });
-        }
+        // WhatsApp Web renamed id._serialized -> id.$1 (2026-07 update) and, on
+        // LID-migrated accounts, the serialized string and the remote wid get
+        // read from different fields ($1 vs remote.$1) that can disagree. Since
+        // media download / revoke / star rebuild their lookup keys from the
+        // remote we expose downstream, reconstruct _serialized from that same
+        // remote so every MsgKey is self-consistent. For non-LID accounts this
+        // reproduces WhatsApp's canonical `fromMe_remote_id[_participant]`
+        // string verbatim, so it is a no-op there.
+        const rebuildKeySerialized = (key) => {
+            if (!key || typeof key !== 'object') return;
+            const remote =
+                typeof key.remote === 'object'
+                    ? key.remote._serialized || key.remote.$1
+                    : key.remote;
+            if (key.id == null || key.fromMe == null || remote == null) {
+                if (key._serialized == null && key.$1 != null) {
+                    key._serialized = key.$1;
+                }
+                return;
+            }
+            const participant =
+                key.participant && typeof key.participant === 'object'
+                    ? key.participant._serialized || key.participant.$1
+                    : key.participant;
+            key._serialized = `${key.fromMe}_${remote}_${key.id}${
+                participant ? '_' + participant : ''
+            }`;
+        };
+
+        rebuildKeySerialized(msg.id);
+        rebuildKeySerialized(msg.msgKey);
+        rebuildKeySerialized(msg.reactionParentKey);
+        rebuildKeySerialized(msg.parentMsgKey);
 
         delete msg.pendingAckUpdate;
 


### PR DESCRIPTION
## What

In `WWebJS.getMessageModel` (injected), reconstruct `id._serialized` from the **same** `remote` wid we expose downstream, in WhatsApp's canonical `fromMe_remote_id[_participant]` form — for `msg.id`, `msgKey`, `reactionParentKey`, and `parentMsgKey`.

## Why

WhatsApp Web's 2026-07 update renamed `id._serialized` → `id.$1`. On **LID-migrated accounts**, `getMessageModel` derived the serialized string (`id.$1`) and the exposed `remote` (`id.remote.$1`) from **independent fields that can disagree**. Downstream operations — media download, revoke, star, quoted-message lookup — rebuild their WA lookup keys from the `remote` we expose, so a mismatched `_serialized` produced empty/incorrect ids (the "LID media download passing empty id" class of failures also fixed in juzibot's `fix/lid-msg-lookup`).

Our prior handling only copied `id.$1` → `_serialized` verbatim and only covered `msg.id`, leaving reaction/poll parent keys and the field-disagreement case unaddressed.

## Approach

- Rebuild `_serialized` from `${fromMe}_${remote}_${id}[_${participant}]`, using the same normalized `remote` we already expose at `Utils.js:835`.
- Applied to all four MsgKey-shaped fields; defensive fallback to the raw `$1` when components are missing.
- **No-op for non-LID accounts**: the reconstruction reproduces WhatsApp's existing canonical `_serialized` string verbatim, so behavior is unchanged there — small blast radius.

## Verification

- Syntax parses; the changed hunk is lint-clean (3 remaining repo lint errors are pre-existing unused-`e` catch vars, unrelated to this change).
- ⚠️ The mocha suite is integration-only (needs a live WhatsApp session), so this can't be unit-verified locally. **Requires validation on a LID-migrated canary instance** (send/receive media, reactions, revoke in a LID group) before rolling to the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)